### PR TITLE
fix missing packages (is empty, not checked)

### DIFF
--- a/packer/scripts/provision.sh
+++ b/packer/scripts/provision.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 sudo pacman -Syyu --noconfirm
+sudo pacman -S iptables libnftnl libmnl  # fix missing packages
 sudo pacman -S htop vim rsync git iproute2 python tar procps --noconfirm


### PR DESCRIPTION
fixes:

```
ldconfig: File /usr/lib/libnftnl.so.4.1.0 is empty, not checked.
ldconfig: File /usr/lib/libiptc.so is empty, not checked.
ldconfig: File /usr/lib/libxtables.so.11 is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so is empty, not checked.
ldconfig: File /usr/lib/libmnl.so.0 is empty, not checked.
ldconfig: File /usr/lib/libmnl.so is empty, not checked.
ldconfig: File /usr/lib/libnftnl.so is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so.0.1.0 is empty, not checked.
ldconfig: File /usr/lib/libnftnl.so.4 is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so.0.1.0 is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libiptc.so.0.0.0 is empty, not checked.
ldconfig: File /usr/lib/libxtables.so.11.0.0 is empty, not checked.
ldconfig: File /usr/lib/libmnl.so.0.2.0 is empty, not checked.
ldconfig: File /usr/lib/libxtables.so is empty, not checked.
ldconfig: File /usr/lib/libiptc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so is empty, not checked.
```

by forcing a reinstall of `iptables libnftnl libmnl`
