### PR TITLE
do not fix missing packages in packer script

### DIFF
--- a/packer/scripts/provision.sh
+++ b/packer/scripts/provision.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 sudo pacman -Syyu --noconfirm
-sudo pacman -S iptables libnftnl libmnl  # fix missing packages
-sudo pacman -S htop vim rsync git iproute2 tar procps --noconfirm
-sudo rm -f /var/lib/pacman/db.lck
+sudo pacman -S htop vim rsync git iproute2 python tar procps --noconfirm


### PR DESCRIPTION
this should instead happen in the vagrant provisioning.
For some reason sshd doesn't come back up after packaging doing it in
`packer/scripts/provisioning.sh`
