### PR TITLE
force reinstall some tools

### DIFF
--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -13,6 +13,5 @@ fi
 rm -f /var/lib/pacman/db.lck
 pacman -Rsc python --noconfirm 2> /dev/null
 pacman -S --force python --noconfirm 2> /dev/null
-
-# Install additional tools
-pacman -S tar procps python2 --noconfirm
+# Ensure additional tools are installed
+pacman -S htop vim rsync git iproute2 python3 python2 tar procps libnftnl popt gpm --force


### PR DESCRIPTION
- libmnl
- libnftnl
- popt
- gpm

to fix:

```
ldconfig: File /usr/lib/libmnl.so is empty, not checked.
ldconfig: File /usr/lib/libiptc.so.0.0.0 is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so is empty, not checked.
ldconfig: File /usr/lib/libpopt.so.0.0.0 is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libxtables.so.11.0.0 is empty, not checked.
ldconfig: File /usr/lib/libgpm.so.2.1.0 is empty, not checked.
ldconfig: File /usr/lib/libpython3.so is empty, not checked.
ldconfig: File /usr/lib/libpopt.so is empty, not checked.
ldconfig: File /usr/lib/libiptc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libnftnl.so.4.1.0 is empty, not checked.
ldconfig: File /usr/lib/libgpm.so is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so is empty, not checked.
ldconfig: File /usr/lib/libpopt.so.0 is empty, not checked.
ldconfig: File /usr/lib/libnftnl.so is empty, not checked.
ldconfig: File /usr/lib/libpython3.5m.so.1.0 is empty, not checked.
ldconfig: File /usr/lib/libpython3.5m.so is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so.0 is empty, not checked.
ldconfig: File /usr/lib/libxtables.so is empty, not checked.
ldconfig: File /usr/lib/libmnl.so.0 is empty, not checked.
ldconfig: File /usr/lib/libmnl.so.0.2.0 is empty, not checked.
ldconfig: File /usr/lib/libip6tc.so.0.1.0 is empty, not checked.
ldconfig: File /usr/lib/libnftnl.so.4 is empty, not checked.
ldconfig: File /usr/lib/libiptc.so is empty, not checked.
ldconfig: File /usr/lib/libxtables.so.11 is empty, not checked.
ldconfig: File /usr/lib/libip4tc.so.0.1.0 is empty, not checked.
ldconfig: File /usr/lib/libgpm.so.2 is empty, not checked.
```
